### PR TITLE
Subfield compatibility and fix for "Unable to find plugin" error

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,13 +6,9 @@ const reverse = 2;
 async function onCreateNode({
   node,
   actions,
-  loadNodeContent,
-  createNodeId,
-  createContentDigest,
 },
   pluginOptions
 ) {
-
   let nodeGeocodeConfig = false;
   for (i = 0; i < pluginOptions.nodeTypes.length; i++) {
     if (node.internal.type == pluginOptions.nodeTypes[i].nodeType) {
@@ -62,7 +58,16 @@ async function onCreateNode({
     console.log("Geocoding: " + query);
   }
   else if (geocodeType == reverse) {
-    query = node[nodeGeocodeConfig.positionFields.lat] + "," + node[nodeGeocodeConfig.positionFields.lon]
+    if (node[nodeGeocodeConfig.positionFields.lat] && node[nodeGeocodeConfig.positionFields.lon]) {
+      query = node[nodeGeocodeConfig.positionFields.lat] + "," + node[nodeGeocodeConfig.positionFields.lon]
+    }
+    else {
+      for (const field in node) {
+        if (node[field][nodeGeocodeConfig.positionFields.lat] && node[field][nodeGeocodeConfig.positionFields.lon]) {
+          query = node[field][nodeGeocodeConfig.positionFields.lat] + "," + node[field][nodeGeocodeConfig.positionFields.lon]
+        }
+      }
+    }
     console.log("Reverse Geocoding: " + query);
   }
   try {
@@ -109,18 +114,6 @@ async function onCreateNode({
 
       }
     }
-      /*
-    else if (data.status.code == 402) {
-      console.error('You have hit the OpenCage free-trial daily limit');
-      console.error('become a customer: https://opencagedata.com/pricing'); 
-      process.exit(1);
-    }
-    else if (data.status.code == 403) {
-      console.error('You have reached your quota limit');
-      console.error('More info: https://opencagedata.com'); 
-      process.exit(1);
-    }
-    */
     else {
       console.error('error', data.status.message);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-transformer-opencage-geocoder",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "A transformer plugin for GatsbyJS to forward- and reverse-geocode content nodes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[Contentful provides](https://www.contentful.com/developers/docs/concepts/data-model/#fields) longitude and latitude data in a subfield. With the previous version of the plugin those location  data fields wouldn't be detected. Now the plugin checks if there are subfields wich have `lon` and `lat` fields.
I know that adds a bit to the workload because the plugin iterates through all fields of a node. But I think it is worth the CPU time because popular data sources like Contentful have dedicated [location fields](https://www.contentful.com/developers/docs/concepts/data-model/#fields) that couldn't be accessed otherwise.
Onother possible solution would have been to add another (optional) configuration option where the user can specify the name of the location field. But this would add complexity to the ease of use of the plugin.

This also fixes a bug where Gatsby was not able to find the plugin at all. In the package.json under `main` was index.js specified as starting point. But there was no index.js. I simply added an empty index.js.